### PR TITLE
First pass at making the LCP license functionality a library.

### DIFF
--- a/lcpserver/api/license.go
+++ b/lcpserver/api/license.go
@@ -10,25 +10,19 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strconv"
 	"time"
-
-	"github.com/gorilla/mux"
 
 	"github.com/readium/readium-lcp-server/api"
 	"github.com/readium/readium-lcp-server/config"
 	"github.com/readium/readium-lcp-server/epub"
-	"github.com/readium/readium-lcp-server/index"
 	"github.com/readium/readium-lcp-server/license"
-	"github.com/readium/readium-lcp-server/problem"
-	"github.com/readium/readium-lcp-server/storage"
 )
 
+// TODO: could have another ErrBadInputLicense etc
 // ErrMandatoryInfoMissing sets an error message returned to the caller
 var ErrMandatoryInfoMissing = errors.New("mandatory info missing in the input body")
 
@@ -198,10 +192,10 @@ func isWebPub(in *zip.Reader) bool {
 	return false
 }
 
-// buildLicensedPublication builds a licensed publication, common to get and generate licensed publication
-func buildLicensedPublication(lic *license.License, s Server) (buf bytes.Buffer, err error) {
+// BuildLicensedPublication builds a licensed publication, common to get and generate licensed publication
+func BuildLicensedPublication(lic *license.License, s Server) (buf bytes.Buffer, contentLocation string, err error) {
 
-	// get content info from the bd
+	// get content info from the db
 	item, err := s.Store().Get(lic.ContentID)
 	if err != nil {
 		return
@@ -209,41 +203,41 @@ func buildLicensedPublication(lic *license.License, s Server) (buf bytes.Buffer,
 	// read the content into a buffer
 	contents, err := item.Contents()
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 	b, err := ioutil.ReadAll(contents)
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 	// create a zip reader
 	zr, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 
 	zipWriter := zip.NewWriter(&buf)
 	err = copyZipFiles(zipWriter, zr)
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 
 	// Encode the license to JSON, remove the trailing newline
 	// write the buffer in the zip
 	licenseBytes, err := json.Marshal(lic)
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 
 	licenseBytes = bytes.TrimRight(licenseBytes, "\n")
 
-	location := epub.LicenseFile
+	licenseLocation := epub.LicenseFile
 	if isWebPub(zr) {
-		location = "license.lcpl"
+		licenseLocation = "license.lcpl"
 	}
 
-	licenseWriter, err := zipWriter.Create(location)
+	licenseWriter, err := zipWriter.Create(licenseLocation)
 	if err != nil {
-		return buf, err
+		return buf, contentLocation, err
 	}
 
 	_, err = licenseWriter.Write(licenseBytes)
@@ -251,491 +245,75 @@ func buildLicensedPublication(lic *license.License, s Server) (buf bytes.Buffer,
 		return
 	}
 
-	return buf, zipWriter.Close()
+	// get the content location to fill an http header
+	// FIXME: redundant as the content location has been set in a link (publication)
+	content, err := s.Index().Get(lic.ContentID)
+	if err != nil {
+		return buf, contentLocation, err
+	}
+	contentLocation = content.Location
+
+	return buf, contentLocation, zipWriter.Close()
 }
 
-// GetLicense returns an existing license,
-// selected by a license id and a partial license both given as input.
-// The input partial license is optional: if absent, a partial license
-// is returned to the caller, with the info stored in the db.
-func GetLicense(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	// get the license id from the request URL
-	licenseID := vars["license_id"]
-
-	log.Println("Get License with id", licenseID)
-
-	// initialize the license from the info stored in the db.
-	var licOut license.License
-	licOut, e := s.Licenses().Get(licenseID)
-	// process license not found etc.
-	if e == license.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusNotFound)
-		return
-	} else if e != nil {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusBadRequest)
-		return
-	}
-	// get the input body.
-	// It contains the hashed passphrase, user hint
-	// and other optional user data the provider wants to see embedded in the license
-	var err error
-	var licIn license.License
-	err = DecodeJSONLicense(r, &licIn)
-	// error parsing the input body
-	if err != nil {
-		// if there was no partial license given as payload, return a partial license.
-		// The use case is a frontend that needs to get license up to date rights.
-		if err.Error() == "EOF" {
-			log.Println("No payload, get a partial license")
-
-			// add useful http headers
-			w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
-			w.WriteHeader(http.StatusPartialContent)
-			// send back the partial license
-			// do not escape characters
-			enc := json.NewEncoder(w)
-			enc.SetEscapeHTML(false)
-			enc.Encode(licOut)
-			return
-		}
-		// unknown error
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
-	}
-
+func GetLicense(licenseID string, licIn *license.License, s Server) (*license.License, error) {
 	// an input body was sent with the request:
 	// check mandatory information in the partial license
-	err = checkGetLicenseInput(&licIn)
+	err := checkGetLicenseInput(licIn)
 	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
+		return nil, err
 	}
+
+	// initialize the license from the info stored in the db.
+	licOut, err := s.Licenses().Get(licenseID)
+	if err != nil {
+		return nil, err
+	}
+
 	// copy useful data from licIn to LicOut
-	copyInputToLicense(&licIn, &licOut)
-	// build the license
+	copyInputToLicense(licIn, &licOut)
+
 	err = buildLicense(&licOut, s, true)
 	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
+		return nil, err
 	}
 
-	// set the http headers
-	w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
-	w.Header().Add("Content-Disposition", `attachment; filename="license.lcpl"`)
-	w.WriteHeader(http.StatusOK)
-	// send back the license
-	// do not escape characters in the json payload
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	enc.Encode(licOut)
+	return &licOut, nil
 }
 
-// GenerateLicense generates and returns a new license,
-// for a given content identified by its id
-// plus a partial license given as input
-func GenerateLicense(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	// get the content id from the request URL
-	contentID := vars["content_id"]
-
-	// get the input body
-	// note: no need to create licIn / licOut here, as the input body contains
-	// info that we want to keep in the full license.
-	var lic license.License
-	err := DecodeJSONLicense(r, &lic)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
+func GenerateLicense(contentID string, lic *license.License, s Server) error {
 	// check mandatory information in the input body
-	err = checkGenerateLicenseInput(&lic)
+	err := checkGenerateLicenseInput(lic)
 	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
+		// TODO: return new bad request error
+		return err
 	}
 	// init the license with an id and issue date
-	license.Initialize(contentID, &lic)
+	license.Initialize(contentID, lic)
 
 	// normalize the start and end date, UTC, no milliseconds
-	setRights(&lic)
+	setRights(lic)
 
 	// build the license
-	err = buildLicense(&lic, s, false)
+	err = buildLicense(lic, s, false)
 	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
+		// TODO: should return ISE
+		return err
 	}
 
 	// store the license in the db
-	err = s.Licenses().Add(lic)
+	err = s.Licenses().Add(*lic)
 	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		//problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: contentID}, http.StatusInternalServerError)
-		return
+		// TODO: should return ISE
+		return err
 	}
-
 	log.Println("New License:", lic.ID, ". Content:", contentID, "User:", lic.User.ID)
-
-	// set http headers
-	w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
-	w.Header().Add("Content-Disposition", `attachment; filename="license.lcpl"`)
-	w.WriteHeader(http.StatusCreated)
-	// send back the license
-	// do not escape characters
-	enc := json.NewEncoder(w)
-	enc.SetEscapeHTML(false)
-	enc.Encode(lic)
 
 	// notify the lsd server of the creation of the license.
 	// this is an asynchronous call.
-	go notifyLsdServer(lic, s)
-}
+	go notifyLsdServer(*lic, s)
 
-// GetLicensedPublication returns a licensed publication
-// for a given license identified by its id
-// plus a partial license given as input
-func GetLicensedPublication(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	licenseID := vars["license_id"]
-
-	log.Println("Get a Licensed publication for license id", licenseID)
-
-	// get the input body
-	var licIn license.License
-	err := DecodeJSONLicense(r, &licIn)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-	// check mandatory information in the input body
-	err = checkGetLicenseInput(&licIn)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-	// initialize the license from the info stored in the db.
-	licOut, e := s.Licenses().Get(licenseID)
-	// process license not found etc.
-	if e == license.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusNotFound)
-		return
-	} else if e != nil {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusBadRequest)
-		return
-	}
-	// copy useful data from licIn to LicOut
-	copyInputToLicense(&licIn, &licOut)
-	// build the license
-	err = buildLicense(&licOut, s, true)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
-	}
-	// build a licensed publication
-	buf, err := buildLicensedPublication(&licOut, s)
-	if err == storage.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: licOut.ContentID}, http.StatusNotFound)
-		return
-	} else if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: licOut.ContentID}, http.StatusInternalServerError)
-		return
-	}
-	// get the content location to fill an http header
-	// FIXME: redundant as the content location has been set in a link (publication)
-	content, err1 := s.Index().Get(licOut.ContentID)
-	if err1 != nil {
-		problem.Error(w, r, problem.Problem{Detail: err1.Error(), Instance: licOut.ContentID}, http.StatusInternalServerError)
-		return
-	}
-	location := content.Location
-
-	// set HTTP headers
-	w.Header().Add("Content-Type", epub.ContentType_EPUB)
-	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, location))
-	// FIXME: check the use of X-Lcp-License by the caller (frontend?)
-	w.Header().Add("X-Lcp-License", licOut.ID)
-	// must come *after* w.Header().Add()/Set(), but before w.Write()
-	w.WriteHeader(http.StatusCreated)
-	// return the full licensed publication to the caller
-	io.Copy(w, &buf)
-}
-
-// GenerateLicensedPublication generates and returns a licensed publication
-// for a given content identified by its id
-// plus a partial license given as input
-func GenerateLicensedPublication(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	contentID := vars["content_id"]
-
-	log.Println("Generate a Licensed publication for content id", contentID)
-
-	// get the input body
-	var lic license.License
-	err := DecodeJSONLicense(r, &lic)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-	// check mandatory information in the input body
-	err = checkGenerateLicenseInput(&lic)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-	// init the license with an id and issue date
-	license.Initialize(contentID, &lic)
-	// normalize the start and end date, UTC, no milliseconds
-	setRights(&lic)
-
-	// build the license
-	err = buildLicense(&lic, s, false)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
-	}
-	// store the license in the db
-	err = s.Licenses().Add(lic)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: contentID}, http.StatusInternalServerError)
-		return
-	}
-
-	// notify the lsd server of the creation of the license
-	go notifyLsdServer(lic, s)
-
-	// build a licenced publication
-	buf, err := buildLicensedPublication(&lic, s)
-	if err == storage.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: lic.ContentID}, http.StatusNotFound)
-		return
-	} else if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: lic.ContentID}, http.StatusInternalServerError)
-		return
-	}
-
-	// get the content location to fill an http header
-	// FIXME: redundant as the content location has been set in a link (publication)
-	content, err1 := s.Index().Get(lic.ContentID)
-	if err1 != nil {
-		problem.Error(w, r, problem.Problem{Detail: err1.Error(), Instance: lic.ContentID}, http.StatusInternalServerError)
-		return
-	}
-	location := content.Location
-
-	// set HTTP headers
-	w.Header().Add("Content-Type", epub.ContentType_EPUB)
-	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, location))
-	// FIXME: check the use of X-Lcp-License by the caller (frontend?)
-	w.Header().Add("X-Lcp-License", lic.ID)
-	// must come *after* w.Header().Add()/Set(), but before w.Write()
-	w.WriteHeader(http.StatusCreated)
-	// return the full licensed publication to the caller
-	io.Copy(w, &buf)
-}
-
-// UpdateLicense updates an existing license.
-// parameters:
-// 		{license_id} in the calling URL
-// 		partial license containing properties which should be updated (and only these)
-// return: an http status code (200, 400 or 404)
-// Usually called from the License Status Server after a renew, return or cancel/revoke action
-// -> updates the end date.
-func UpdateLicense(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	// get the license id from the request URL
-	licenseID := vars["license_id"]
-
-	log.Println("Update License with id", licenseID)
-
-	var licIn license.License
-	err := DecodeJSONLicense(r, &licIn)
-	if err != nil { // no or incorrect (json) partial license found in the body
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-	// initialize the license from the info stored in the db.
-	var licOut license.License
-	licOut, e := s.Licenses().Get(licenseID)
-	// process license not found etc.
-	if e == license.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusNotFound)
-		return
-	} else if e != nil {
-		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusBadRequest)
-		return
-	}
-	// update licOut using information found in licIn
-	if licIn.User.ID != "" {
-		log.Println("new user id: ", licIn.User.ID)
-		licOut.User.ID = licIn.User.ID
-	}
-	if licIn.Provider != "" {
-		log.Println("new provider: ", licIn.Provider)
-		licOut.Provider = licIn.Provider
-	}
-	if licIn.ContentID != "" {
-		log.Println("new content id: ", licIn.ContentID)
-		licOut.ContentID = licIn.ContentID
-	}
-	if licIn.Rights.Print != nil {
-		log.Println("new right, print: ", *licIn.Rights.Print)
-		licOut.Rights.Print = licIn.Rights.Print
-	}
-	if licIn.Rights.Copy != nil {
-		log.Println("new right, copy: ", *licIn.Rights.Copy)
-		licOut.Rights.Copy = licIn.Rights.Copy
-	}
-	if licIn.Rights.Start != nil {
-		log.Println("new right, start: ", *licIn.Rights.Start)
-		licOut.Rights.Start = licIn.Rights.Start
-	}
-	if licIn.Rights.End != nil {
-		log.Println("new right, end: ", *licIn.Rights.End)
-		licOut.Rights.End = licIn.Rights.End
-	}
-	// update the license in the database
-	err = s.Licenses().Update(licOut)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
-		return
-	}
-}
-
-// ListLicenses returns a JSON struct with information about the existing licenses
-// parameters:
-// 	page: page number
-//	per_page: number of items par page
-func ListLicenses(w http.ResponseWriter, r *http.Request, s Server) {
-
-	var page int64
-	var perPage int64
-	var err error
-	if r.FormValue("page") != "" {
-		page, err = strconv.ParseInt((r).FormValue("page"), 10, 32)
-		if err != nil {
-			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-			return
-		}
-	} else {
-		page = 1
-	}
-	if r.FormValue("per_page") != "" {
-		perPage, err = strconv.ParseInt((r).FormValue("per_page"), 10, 32)
-		if err != nil {
-			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-			return
-		}
-	} else {
-		perPage = 30
-	}
-	if page > 0 { //pagenum starting at 0 in code, but user interface starting at 1
-		page--
-	}
-	if page < 0 {
-		problem.Error(w, r, problem.Problem{Detail: "page must be positive integer"}, http.StatusBadRequest)
-		return
-	}
-	licenses := make([]license.LicenseReport, 0)
-	//log.Println("ListAll(" + strconv.Itoa(int(per_page)) + "," + strconv.Itoa(int(page)) + ")")
-	fn := s.Licenses().ListAll(int(perPage), int(page))
-	for it, err := fn(); err == nil; it, err = fn() {
-		licenses = append(licenses, it)
-	}
-	if len(licenses) > 0 {
-		nextPage := strconv.Itoa(int(page) + 1)
-		w.Header().Set("Link", "</licenses/?page="+nextPage+">; rel=\"next\"; title=\"next\"")
-	}
-	if page > 1 {
-		previousPage := strconv.Itoa(int(page) - 1)
-		w.Header().Set("Link", "</licenses/?page="+previousPage+">; rel=\"previous\"; title=\"previous\"")
-	}
-	w.Header().Set("Content-Type", api.ContentType_JSON)
-
-	enc := json.NewEncoder(w)
-	// do not escape characters
-	enc.SetEscapeHTML(false)
-	err = enc.Encode(licenses)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-}
-
-// ListLicensesForContent lists all licenses associated with a given content
-// parameters:
-//	content_id: content identifier
-// 	page: page number (default 1)
-//	per_page: number of items par page (default 30)
-func ListLicensesForContent(w http.ResponseWriter, r *http.Request, s Server) {
-
-	vars := mux.Vars(r)
-	var page int64
-	var perPage int64
-	var err error
-	contentID := vars["content_id"]
-
-	//check if the license exists
-	_, err = s.Index().Get(contentID)
-	if err == index.ErrNotFound {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusNotFound)
-		return
-	} //other errors pass, but will probably reoccur
-	if r.FormValue("page") != "" {
-		page, err = strconv.ParseInt(r.FormValue("page"), 10, 32)
-		if err != nil {
-			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-			return
-		}
-	} else {
-		page = 1
-	}
-
-	if r.FormValue("per_page") != "" {
-		perPage, err = strconv.ParseInt((r).FormValue("per_page"), 10, 32)
-		if err != nil {
-			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-			return
-		}
-	} else {
-		perPage = 30
-	}
-	if page > 0 {
-		page-- //pagenum starting at 0 in code, but user interface starting at 1
-	}
-	if page < 0 {
-		problem.Error(w, r, problem.Problem{Detail: "page must be positive integer"}, http.StatusBadRequest)
-		return
-	}
-	licenses := make([]license.LicenseReport, 0)
-	//log.Println("List(" + contentId + "," + strconv.Itoa(int(per_page)) + "," + strconv.Itoa(int(page)) + ")")
-	fn := s.Licenses().ListByContentID(contentID, int(perPage), int(page))
-	for it, err := fn(); err == nil; it, err = fn() {
-		licenses = append(licenses, it)
-	}
-	if len(licenses) > 0 {
-		nextPage := strconv.Itoa(int(page) + 1)
-		w.Header().Set("Link", "</licenses/?page="+nextPage+">; rel=\"next\"; title=\"next\"")
-	}
-	if page > 1 {
-		previousPage := strconv.Itoa(int(page) - 1)
-		w.Header().Set("Link", "</licenses/?page="+previousPage+">; rel=\"previous\"; title=\"previous\"")
-	}
-	w.Header().Set("Content-Type", api.ContentType_JSON)
-	enc := json.NewEncoder(w)
-	// do not escape characters
-	enc.SetEscapeHTML(false)
-	err = enc.Encode(licenses)
-	if err != nil {
-		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
-		return
-	}
-
+	return nil
 }
 
 // DecodeJSONLicense decodes a license formatted in json and returns a license object

--- a/lcpserver/api/license.go
+++ b/lcpserver/api/license.go
@@ -308,14 +308,12 @@ func GenerateLicense(contentID string, lic *license.License, s Server) error {
 	// build the license
 	err = buildLicense(lic, s, false)
 	if err != nil {
-		// TODO: should return ISE
 		return err
 	}
 
 	// store the license in the db
 	err = s.Licenses().Add(*lic)
 	if err != nil {
-		// TODO: should return ISE
 		return err
 	}
 	log.Println("New License:", lic.ID, ". Content:", contentID, "User:", lic.User.ID)

--- a/lcpserver/api/license_handlers.go
+++ b/lcpserver/api/license_handlers.go
@@ -1,0 +1,468 @@
+// Copyright 2017 Readium Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style license
+// that can be found in the LICENSE file exposed on Github (readium) in the project repository.
+
+package apilcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/readium/readium-lcp-server/api"
+	"github.com/readium/readium-lcp-server/epub"
+	"github.com/readium/readium-lcp-server/index"
+	"github.com/readium/readium-lcp-server/license"
+	"github.com/readium/readium-lcp-server/problem"
+	"github.com/readium/readium-lcp-server/storage"
+)
+
+// GetLicenseHandler returns an existing license,
+// selected by a license id and a partial license both given as input.
+// The input partial license is optional: if absent, a partial license
+// is returned to the caller, with the info stored in the db.
+func GetLicenseHandler(w http.ResponseWriter, r *http.Request, s Server) {
+	// get the input body.
+	// It contains the hashed passphrase, user hint
+	// and other optional user data the provider wants to see embedded in the license
+	var licIn license.License
+	err := DecodeJSONLicense(r, &licIn)
+	// error parsing the input body
+	if err != nil {
+		// if there was no partial license given as payload, return a partial license.
+		// The use case is a frontend that needs to get license up to date rights.
+		if err.Error() == "EOF" {
+			log.Println("No payload, get a partial license")
+
+			// add useful http headers
+			w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
+			w.WriteHeader(http.StatusPartialContent)
+			// send back the partial license
+			writeResponseLicense(w, r, &licIn, s)
+			return
+		}
+		// unknown error
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+
+	// set the http headers
+	w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
+	w.Header().Add("Content-Disposition", `attachment; filename="license.lcpl"`)
+	w.WriteHeader(http.StatusOK)
+
+	writeResponseLicense(w, r, &licIn, s)
+}
+
+func writeResponseLicense(w http.ResponseWriter, r *http.Request, licIn *license.License, s Server) {
+	// send back the license
+	// do not escape characters in the json payload
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	licOut := getExistingLicense(w, r, licIn, s)
+	if licOut != nil {
+		err := enc.Encode(licOut)
+		if err != nil {
+			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		}
+	}
+}
+
+func getExistingLicense(w http.ResponseWriter, r *http.Request, licIn *license.License, s Server) *license.License {
+	vars := mux.Vars(r)
+	// get the license id from the request URL
+	licenseID := vars["license_id"]
+
+	log.Println("Get License with id", licenseID)
+	// initialize the license from the info stored in the db.
+	licOut, err := GetLicense(licenseID, licIn, s)
+	// process license not found etc.
+	if err == license.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusNotFound)
+		return nil
+	} else if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return nil
+	}
+	return licOut
+}
+
+// GenerateLicenseHandler generates and returns a new license,
+// for a given content identified by its id
+// plus a partial license given as input
+func GenerateLicenseHandler(w http.ResponseWriter, r *http.Request, s Server) {
+
+	vars := mux.Vars(r)
+	// get the content id from the request URL
+	contentID := vars["content_id"]
+
+	// get the input body
+	// note: no need to create licIn / licOut here, as the input body contains
+	// info that we want to keep in the full license.
+	var lic license.License
+	err := DecodeJSONLicense(r, &lic)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}
+
+	GenerateLicense(contentID, &lic, s)
+	// TODO: handles errors from checkGeneratedLIcenseInput
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}*/
+
+	// TODO: handle license build error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}*/
+
+	// TODO: handle license store error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		//problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: contentID}, http.StatusInternalServerError)
+		return
+	}*/
+
+	// set http headers
+	w.Header().Add("Content-Type", api.ContentType_LCP_JSON)
+	w.Header().Add("Content-Disposition", `attachment; filename="license.lcpl"`)
+	w.WriteHeader(http.StatusCreated)
+	// send back the license
+	// do not escape characters
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	enc.Encode(lic)
+}
+
+// GetLicensedPublication returns a licensed publication
+// for a given license identified by its id
+// plus a partial license given as input
+func GetLicensedPublication(w http.ResponseWriter, r *http.Request, s Server) {
+
+	vars := mux.Vars(r)
+	licenseID := vars["license_id"]
+
+	log.Println("Get a Licensed publication for license id", licenseID)
+
+	// TODO: could be a  get input license helper
+	// get the input body
+	var licIn license.License
+	err := DecodeJSONLicense(r, &licIn)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}
+
+	licOut, err := GetLicense(licenseID, &licIn, s)
+	// TODO: handle bad request error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}*/
+
+	// TODO: Licenses().get(licenseID) failures
+	// process license not found etc.
+	/*if e == license.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusNotFound)
+		return
+	} else if e != nil {
+		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusBadRequest)
+		return
+	}*/
+
+	// TODO: build license failures
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}*/
+
+	// build a licensed publication
+	err = writeLicensedPublication(licOut, w, s)
+	if err == storage.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: licOut.ContentID}, http.StatusNotFound)
+		return
+	} else if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: licOut.ContentID}, http.StatusInternalServerError)
+		return
+	}
+}
+
+// GenerateLicensedPublication generates and returns a licensed publication
+// for a given content identified by its id
+// plus a partial license given as input
+func GenerateLicensedPublication(w http.ResponseWriter, r *http.Request, s Server) {
+
+	vars := mux.Vars(r)
+	contentID := vars["content_id"]
+
+	log.Println("Generate a Licensed publication for content id", contentID)
+
+	// get the input body
+	var lic license.License
+	err := DecodeJSONLicense(r, &lic)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+
+	}
+
+	err = GenerateLicense(contentID, &lic, s)
+	// TODO: handle badInput error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}*/
+
+	// TODO: handle buildLicense error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}*/
+
+	// TODO: handle add error
+	/*if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: contentID}, http.StatusInternalServerError)
+		return
+	}*/
+
+	// notify the lsd server of the creation of the license
+	go notifyLsdServer(lic, s)
+
+	err = writeLicensedPublication(&lic, w, s)
+	if err == storage.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: lic.ContentID}, http.StatusNotFound)
+		return
+	} else if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error(), Instance: lic.ContentID}, http.StatusInternalServerError)
+		return
+	}
+}
+
+func writeLicensedPublication(lic *license.License, w http.ResponseWriter, s Server) error {
+	// build a licenced publication
+	buf, location, err := BuildLicensedPublication(lic, s)
+	if err != nil {
+		return err
+	}
+	// set HTTP headers
+	w.Header().Add("Content-Type", epub.ContentType_EPUB)
+	w.Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, location))
+	// FIXME: check the use of X-Lcp-License by the caller (frontend?)
+	w.Header().Add("X-Lcp-License", lic.ID)
+	// must come *after* w.Header().Add()/Set(), but before w.Write()
+	w.WriteHeader(http.StatusCreated)
+	// return the full licensed publication to the caller
+	io.Copy(w, &buf)
+	return nil
+}
+
+// UpdateLicense updates an existing license.
+// parameters:
+//
+//	{license_id} in the calling URL
+//	partial license containing properties which should be updated (and only these)
+//
+// return: an http status code (200, 400 or 404)
+// Usually called from the License Status Server after a renew, return or cancel/revoke action
+// -> updates the end date.
+func UpdateLicense(w http.ResponseWriter, r *http.Request, s Server) {
+
+	vars := mux.Vars(r)
+	// get the license id from the request URL
+	licenseID := vars["license_id"]
+
+	log.Println("Update License with id", licenseID)
+
+	var licIn license.License
+	err := DecodeJSONLicense(r, &licIn)
+	if err != nil { // no or incorrect (json) partial license found in the body
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}
+	// initialize the license from the info stored in the db.
+	var licOut license.License
+	licOut, e := s.Licenses().Get(licenseID)
+	// process license not found etc.
+	if e == license.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusNotFound)
+		return
+	} else if e != nil {
+		problem.Error(w, r, problem.Problem{Detail: e.Error()}, http.StatusBadRequest)
+		return
+	}
+	// update licOut using information found in licIn
+	if licIn.User.ID != "" {
+		log.Println("new user id: ", licIn.User.ID)
+		licOut.User.ID = licIn.User.ID
+	}
+	if licIn.Provider != "" {
+		log.Println("new provider: ", licIn.Provider)
+		licOut.Provider = licIn.Provider
+	}
+	if licIn.ContentID != "" {
+		log.Println("new content id: ", licIn.ContentID)
+		licOut.ContentID = licIn.ContentID
+	}
+	if licIn.Rights.Print != nil {
+		log.Println("new right, print: ", *licIn.Rights.Print)
+		licOut.Rights.Print = licIn.Rights.Print
+	}
+	if licIn.Rights.Copy != nil {
+		log.Println("new right, copy: ", *licIn.Rights.Copy)
+		licOut.Rights.Copy = licIn.Rights.Copy
+	}
+	if licIn.Rights.Start != nil {
+		log.Println("new right, start: ", *licIn.Rights.Start)
+		licOut.Rights.Start = licIn.Rights.Start
+	}
+	if licIn.Rights.End != nil {
+		log.Println("new right, end: ", *licIn.Rights.End)
+		licOut.Rights.End = licIn.Rights.End
+	}
+	// update the license in the database
+	err = s.Licenses().Update(licOut)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusInternalServerError)
+		return
+	}
+}
+
+// ListLicenses returns a JSON struct with information about the existing licenses
+// parameters:
+//
+//	page: page number
+//	per_page: number of items par page
+func ListLicenses(w http.ResponseWriter, r *http.Request, s Server) {
+
+	var page int64
+	var perPage int64
+	var err error
+	if r.FormValue("page") != "" {
+		page, err = strconv.ParseInt((r).FormValue("page"), 10, 32)
+		if err != nil {
+			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+			return
+		}
+	} else {
+		page = 1
+	}
+	if r.FormValue("per_page") != "" {
+		perPage, err = strconv.ParseInt((r).FormValue("per_page"), 10, 32)
+		if err != nil {
+			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+			return
+		}
+	} else {
+		perPage = 30
+	}
+	if page > 0 { //pagenum starting at 0 in code, but user interface starting at 1
+		page--
+	}
+	if page < 0 {
+		problem.Error(w, r, problem.Problem{Detail: "page must be positive integer"}, http.StatusBadRequest)
+		return
+	}
+	licenses := make([]license.LicenseReport, 0)
+	//log.Println("ListAll(" + strconv.Itoa(int(per_page)) + "," + strconv.Itoa(int(page)) + ")")
+	fn := s.Licenses().ListAll(int(perPage), int(page))
+	for it, err := fn(); err == nil; it, err = fn() {
+		licenses = append(licenses, it)
+	}
+	if len(licenses) > 0 {
+		nextPage := strconv.Itoa(int(page) + 1)
+		w.Header().Set("Link", "</licenses/?page="+nextPage+">; rel=\"next\"; title=\"next\"")
+	}
+	if page > 1 {
+		previousPage := strconv.Itoa(int(page) - 1)
+		w.Header().Set("Link", "</licenses/?page="+previousPage+">; rel=\"previous\"; title=\"previous\"")
+	}
+	w.Header().Set("Content-Type", api.ContentType_JSON)
+
+	enc := json.NewEncoder(w)
+	// do not escape characters
+	enc.SetEscapeHTML(false)
+	err = enc.Encode(licenses)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}
+}
+
+// ListLicensesForContent lists all licenses associated with a given content
+// parameters:
+//
+//	content_id: content identifier
+//	page: page number (default 1)
+//	per_page: number of items par page (default 30)
+func ListLicensesForContent(w http.ResponseWriter, r *http.Request, s Server) {
+
+	vars := mux.Vars(r)
+	var page int64
+	var perPage int64
+	var err error
+	contentID := vars["content_id"]
+
+	//check if the license exists
+	_, err = s.Index().Get(contentID)
+	if err == index.ErrNotFound {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusNotFound)
+		return
+	} //other errors pass, but will probably reoccur
+	if r.FormValue("page") != "" {
+		page, err = strconv.ParseInt(r.FormValue("page"), 10, 32)
+		if err != nil {
+			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+			return
+		}
+	} else {
+		page = 1
+	}
+
+	if r.FormValue("per_page") != "" {
+		perPage, err = strconv.ParseInt((r).FormValue("per_page"), 10, 32)
+		if err != nil {
+			problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+			return
+		}
+	} else {
+		perPage = 30
+	}
+	if page > 0 {
+		page-- //pagenum starting at 0 in code, but user interface starting at 1
+	}
+	if page < 0 {
+		problem.Error(w, r, problem.Problem{Detail: "page must be positive integer"}, http.StatusBadRequest)
+		return
+	}
+	licenses := make([]license.LicenseReport, 0)
+	//log.Println("List(" + contentId + "," + strconv.Itoa(int(per_page)) + "," + strconv.Itoa(int(page)) + ")")
+	fn := s.Licenses().ListByContentID(contentID, int(perPage), int(page))
+	for it, err := fn(); err == nil; it, err = fn() {
+		licenses = append(licenses, it)
+	}
+	if len(licenses) > 0 {
+		nextPage := strconv.Itoa(int(page) + 1)
+		w.Header().Set("Link", "</licenses/?page="+nextPage+">; rel=\"next\"; title=\"next\"")
+	}
+	if page > 1 {
+		previousPage := strconv.Itoa(int(page) - 1)
+		w.Header().Set("Link", "</licenses/?page="+previousPage+">; rel=\"previous\"; title=\"previous\"")
+	}
+	w.Header().Set("Content-Type", api.ContentType_JSON)
+	enc := json.NewEncoder(w)
+	// do not escape characters
+	enc.SetEscapeHTML(false)
+	err = enc.Encode(licenses)
+	if err != nil {
+		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
+		return
+	}
+
+}

--- a/lcpserver/server/server.go
+++ b/lcpserver/server/server.go
@@ -133,7 +133,7 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}/publication", apilcp.GetLicensedPublication, basicAuth).Methods("POST")
 	if !readonly {
 		// update a license
-		s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.UpdateLicense, basicAuth).Methods("PATCH")
+		s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.UpdateLicenseHandler, basicAuth).Methods("PATCH")
 	}
 
 	s.source.Feed(packager.Incoming)

--- a/lcpserver/server/server.go
+++ b/lcpserver/server/server.go
@@ -105,7 +105,7 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 	// get encrypted content by content id (a uuid)
 	s.handleFunc(contentRoutes, "/{content_id}", apilcp.GetContent).Methods("GET")
 	// get all licenses associated with a given content
-	s.handlePrivateFunc(contentRoutes, "/{content_id}/licenses", apilcp.ListLicensesForContent, basicAuth).Methods("GET")
+	s.handlePrivateFunc(contentRoutes, "/{content_id}/licenses", apilcp.ListLicensesForContentHandler, basicAuth).Methods("GET")
 
 	if !readonly {
 		// put content to the storage
@@ -125,12 +125,12 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 	licenseRoutesPathPrefix := "/licenses"
 	licenseRoutes := sr.R.PathPrefix(licenseRoutesPathPrefix).Subrouter().StrictSlash(false)
 
-	s.handlePrivateFunc(sr.R, licenseRoutesPathPrefix, apilcp.ListLicenses, basicAuth).Methods("GET")
+	s.handlePrivateFunc(sr.R, licenseRoutesPathPrefix, apilcp.ListLicensesHandler, basicAuth).Methods("GET")
 	// get a license
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicenseHandler, basicAuth).Methods("GET")
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicenseHandler, basicAuth).Methods("POST")
 	// get a licensed publication via a license id
-	s.handlePrivateFunc(licenseRoutes, "/{license_id}/publication", apilcp.GetLicensedPublication, basicAuth).Methods("POST")
+	s.handlePrivateFunc(licenseRoutes, "/{license_id}/publication", apilcp.GetLicensedPublicationHandler, basicAuth).Methods("POST")
 	if !readonly {
 		// update a license
 		s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.UpdateLicenseHandler, basicAuth).Methods("PATCH")

--- a/lcpserver/server/server.go
+++ b/lcpserver/server/server.go
@@ -111,9 +111,9 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 		// put content to the storage
 		s.handlePrivateFunc(contentRoutes, "/{content_id}", apilcp.AddContent, basicAuth).Methods("PUT")
 		// generate a license for given content
-		s.handlePrivateFunc(contentRoutes, "/{content_id}/license", apilcp.GenerateLicense, basicAuth).Methods("POST")
+		s.handlePrivateFunc(contentRoutes, "/{content_id}/license", apilcp.GenerateLicenseHandler, basicAuth).Methods("POST")
 		// deprecated, from a typo in the lcp server spec
-		s.handlePrivateFunc(contentRoutes, "/{content_id}/licenses", apilcp.GenerateLicense, basicAuth).Methods("POST")
+		s.handlePrivateFunc(contentRoutes, "/{content_id}/licenses", apilcp.GenerateLicenseHandler, basicAuth).Methods("POST")
 		// generate a licensed publication
 		s.handlePrivateFunc(contentRoutes, "/{content_id}/publication", apilcp.GenerateLicensedPublication, basicAuth).Methods("POST")
 		// deprecated, from a typo in the lcp server spec
@@ -127,8 +127,8 @@ func New(bindAddr string, readonly bool, idx *index.Index, st *storage.Store, ls
 
 	s.handlePrivateFunc(sr.R, licenseRoutesPathPrefix, apilcp.ListLicenses, basicAuth).Methods("GET")
 	// get a license
-	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicense, basicAuth).Methods("GET")
-	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicense, basicAuth).Methods("POST")
+	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicenseHandler, basicAuth).Methods("GET")
+	s.handlePrivateFunc(licenseRoutes, "/{license_id}", apilcp.GetLicenseHandler, basicAuth).Methods("POST")
 	// get a licensed publication via a license id
 	s.handlePrivateFunc(licenseRoutes, "/{license_id}/publication", apilcp.GetLicensedPublication, basicAuth).Methods("POST")
 	if !readonly {

--- a/license/license_test.go
+++ b/license/license_test.go
@@ -18,7 +18,9 @@ func TestLicense(t *testing.T) {
 
 	SetLicenseProfile(&l)
 
-	if l.Encryption.Profile != "1.0" && l.Encryption.Profile != "basic" {
-		t.Errorf("Expected '1.0' or 'basic', got %s", l.Encryption.Profile)
+	basic := "http://readium.org/lcp/basic-profile"
+	one := "http://readium.org/lcp/profile-1.0"
+	if l.Encryption.Profile != one && l.Encryption.Profile != basic {
+		t.Errorf("Expected '%s' or '%s', got %s", basic, one, l.Encryption.Profile)
 	}
 }

--- a/lsdserver/api/freshlicense_test.go
+++ b/lsdserver/api/freshlicense_test.go
@@ -17,7 +17,7 @@ var LicenseID string = "812bbfe8-9a57-4b14-b8f3-4e0fc6e841c0"
 func TestGetUserData(t *testing.T) {
 
 	// enter here a valid URL
-	config.Config.LsdServer.UserDataUrl = "http://xx.xx.xx.xx:pppp/aaaaa/{license_id}/aaaa"
+	config.Config.LsdServer.UserDataUrl = "http://xx.xx.xx.xx:9999/aaaaa/{license_id}/aaaa"
 	// enter here valid credentials
 	config.Config.CMSAccessAuth.Username = "xxxxx"
 	config.Config.CMSAccessAuth.Password = "xxxxx"
@@ -63,7 +63,7 @@ func TestInitPartialLicense(t *testing.T) {
 func TestFetchLicense(t *testing.T) {
 
 	// enter here a valid URL
-	config.Config.LcpServer.PublicBaseUrl = "http://xx.xx.xx.xx:pppp"
+	config.Config.LcpServer.PublicBaseUrl = "http://xx.xx.xx.xx:9999"
 	// enter here valid credentials
 	config.Config.LcpUpdateAuth.Username = "xxxx"
 	config.Config.LcpUpdateAuth.Password = "xxxx"

--- a/lsdserver/api/license_status.go
+++ b/lsdserver/api/license_status.go
@@ -40,7 +40,7 @@ type Server interface {
 // It is triggered by a notification from the license server
 func CreateLicenseStatusDocument(w http.ResponseWriter, r *http.Request, s Server) {
 	var lic license.License
-	err := apilcp.DecodeJSONLicense(r, &lic)
+	err := apilcp.DecodeJSONLicenseFromReq(r, &lic)
 
 	if err != nil {
 		problem.Error(w, r, problem.Problem{Detail: err.Error()}, http.StatusBadRequest)
@@ -131,7 +131,6 @@ func GetLicenseStatusDocument(w http.ResponseWriter, r *http.Request, s Server) 
 // RegisterDevice registers a device for a given license,
 // using the device id &  name as  parameters;
 // returns the updated license status
-//
 func RegisterDevice(w http.ResponseWriter, r *http.Request, s Server) {
 
 	w.Header().Set("Content-Type", api.ContentType_LSD_JSON)
@@ -646,6 +645,7 @@ func ListRegisteredDevices(w http.ResponseWriter, r *http.Request, s Server) {
 
 // LendingCancellation cancels (before use) or revokes (after use)  a license.
 // parameters:
+//
 //	key: license id
 //	partial license status: the new status and a message indicating why the status is being changed
 //	The new status can be either STATUS_CANCELLED or STATUS_REVOKED


### PR DESCRIPTION
Goal: Wrap more of the functionality of LCP server into **exported** functions that can be used as a library from other Go services.

For example it's useful to wrap validation things like `checkGetLicenseInput`, `copyInputToLicense`, `buildLicense`, etc inside a single, exported function that can be called from outside an HTTP handler.